### PR TITLE
change react external def for webpack

### DIFF
--- a/bin/config.js
+++ b/bin/config.js
@@ -37,7 +37,7 @@ const getConfig = ({ entry, out, libraryName, bundleName, minify, presets }) => 
     library: libraryName,
   },
   externals: {
-    react: 'React',
+    react: 'react',
   },
   module: {
     loaders: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-build-dist",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A simple utility for compiling your React components to standalone modules.",
   "bin": {
     "react-build-dist": "./bin/index.js"
@@ -9,6 +9,10 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Adrian Li",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adrianmcli/react-build-dist.git"
+  },
   "license": "ISC",
   "dependencies": {
     "babel-core": "^6.21.0",


### PR DESCRIPTION
This fixes an issue I had on Linux boxes. They were not able to resolve the external `React` correctly even though on my Mac env it did. I don't think this will break any previous implementations, this should only expand compatibility.